### PR TITLE
Add basic real estate calculator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# Prueba-Codex
-Repositorio para hecer pruebas con codex
+# Calculadora Inmobiliaria Web
+
+Aplicación web sencilla para estimar beneficios de la venta de una vivienda y simular inversiones inmobiliarias múltiples.
+
+## Estructura
+- `index.html`: punto de entrada que carga React y Tailwind desde CDN.
+- `src/main.jsx`: componentes React con los dos módulos solicitados.
+
+## Uso
+1. Abrir `index.html` en un navegador con conexión a Internet (se cargan las dependencias desde CDN).
+2. Navegar entre los módulos mediante los botones en la parte superior.
+3. Introducir los datos necesarios para obtener los cálculos en tiempo real.
+
+No se requiere entorno de construcción; todo se ejecuta en el navegador.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calculadora Inmobiliaria</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body class="bg-gray-100 text-gray-900">
+    <div id="root"></div>
+    <script type="text/babel" src="./src/main.jsx"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,20 @@
 <!DOCTYPE html>
+<!-- Archivo HTML principal que carga React, ReactDOM, Babel y Tailwind desde CDNs -->
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Calculadora Inmobiliaria</title>
+    <!-- Librerías externas para estilos y React -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body class="bg-gray-100 text-gray-900">
+    <!-- Punto de montaje de la aplicación React -->
     <div id="root"></div>
+    <!-- Carga del código JSX principal -->
     <script type="text/babel" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
+// Archivo principal con los módulos de Venta e Inversión
 const { useState } = React;
 
+// Componente raíz que controla la navegación entre módulos
 function App() {
   const [module, setModule] = useState('venta');
   const [capitalDisponible, setCapitalDisponible] = useState(0);
   const [netoVenta, setNetoVenta] = useState(0);
 
+  // Guarda el neto de la venta para usarlo en el módulo de inversión
   const handleNeto = (valor) => {
     setNetoVenta(valor);
     setCapitalDisponible(valor);
@@ -25,6 +28,7 @@ function App() {
   );
 }
 
+// Calculadora de venta de vivienda. Devuelve el dinero neto tras la operación.
 function VentaCalculator({ onNeto }) {
   const [precioVenta, setPrecioVenta] = useState(300000);
   const [precioCompra, setPrecioCompra] = useState(200000);
@@ -43,6 +47,7 @@ function VentaCalculator({ onNeto }) {
   const plusvalia = Math.max(precioVenta - precioCompra, 0);
   const plusvaliaMunicipal = plusvalia * (gastos.plusvaliaMunicipal / 100);
 
+  // Calcula el impuesto sobre la renta por ganancia patrimonial según tramos
   function calcIRPF(gain) {
     let restante = gain;
     let impuesto = 0;
@@ -70,10 +75,12 @@ function VentaCalculator({ onNeto }) {
   const totalGastos = plusvaliaMunicipal + impuestoRenta + comision + notaria + registro + gestoria + otros + hipotecaPendiente;
   const neto = precioVenta - totalGastos;
 
+  // Actualiza el neto calculado al cambiar cualquier dato
   React.useEffect(() => {
     onNeto(neto);
   }, [neto]);
 
+  // Actualiza porcentajes de gasto de forma dinámica
   const handleGastoChange = (campo, valor) => {
     setGastos(prev => ({ ...prev, [campo]: parseFloat(valor) }));
   };
@@ -126,9 +133,11 @@ function VentaCalculator({ onNeto }) {
   );
 }
 
+// Simulador de inversión para múltiples propiedades
 function InversionSimulator({ capitalDisponible, setCapitalDisponible }) {
   const [propiedades, setPropiedades] = useState([]);
 
+  // Añade una nueva propiedad con valores por defecto
   const addPropiedad = () => {
     setPropiedades(prev => [...prev, {
       id: Date.now(),
@@ -145,14 +154,17 @@ function InversionSimulator({ capitalDisponible, setCapitalDisponible }) {
     }]);
   };
 
+  // Elimina una propiedad del listado
   const removePropiedad = (id) => {
     setPropiedades(prev => prev.filter(p=>p.id!==id));
   };
 
+  // Actualiza un campo específico de una propiedad
   const handleChange = (id, campo, valor) => {
     setPropiedades(prev => prev.map(p => p.id===id?{...p,[campo]:parseFloat(valor)||0}:p));
   };
 
+  // Obtiene métricas financieras para una propiedad
   const calcular = (p) => {
     const entrada = p.precioCompra * (p.entradaPorcentaje/100);
     const hipoteca = p.precioCompra - entrada;
@@ -168,6 +180,7 @@ function InversionSimulator({ capitalDisponible, setCapitalDisponible }) {
     return { entrada, hipoteca, cuota, ingresoBruto, ingresoNeto, cashflow, roi, rentabilidad };
   };
 
+  // Acumula métricas globales del conjunto de propiedades
   const resumen = propiedades.reduce((acc,p)=>{
     const r = calcular(p);
     acc.capitalUsado += r.entrada + (p.precioCompra*(p.gastosCompra/100)) + p.gastosReforma;
@@ -260,4 +273,5 @@ function InversionSimulator({ capitalDisponible, setCapitalDisponible }) {
   );
 }
 
+// Monta la aplicación en el DOM
 ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,263 @@
+const { useState } = React;
+
+function App() {
+  const [module, setModule] = useState('venta');
+  const [capitalDisponible, setCapitalDisponible] = useState(0);
+  const [netoVenta, setNetoVenta] = useState(0);
+
+  const handleNeto = (valor) => {
+    setNetoVenta(valor);
+    setCapitalDisponible(valor);
+  };
+
+  return (
+    <div className="p-4 max-w-6xl mx-auto">
+      <header className="mb-4 flex gap-4">
+        <button className={`px-4 py-2 rounded ${module==='venta'?'bg-blue-600 text-white':'bg-gray-200'}`} onClick={() => setModule('venta')}>Venta</button>
+        <button className={`px-4 py-2 rounded ${module==='inversion'?'bg-blue-600 text-white':'bg-gray-200'}`} onClick={() => setModule('inversion')}>Inversión</button>
+      </header>
+      {module === 'venta' ? (
+        <VentaCalculator onNeto={handleNeto} />
+      ) : (
+        <InversionSimulator capitalDisponible={capitalDisponible} setCapitalDisponible={setCapitalDisponible} />
+      )}
+    </div>
+  );
+}
+
+function VentaCalculator({ onNeto }) {
+  const [precioVenta, setPrecioVenta] = useState(300000);
+  const [precioCompra, setPrecioCompra] = useState(200000);
+  const [añosPropiedad, setAñosPropiedad] = useState(5);
+  const [hipotecaPendiente, setHipotecaPendiente] = useState(60000);
+  const [gastos, setGastos] = useState({
+    plusvaliaMunicipal: 7,
+    impuestoRenta: 19,
+    comisionAgencia: 4,
+    notaria: 0.3,
+    registro: 0.15,
+    gestoria: 0.5,
+    otros: 1.2,
+  });
+
+  const plusvalia = Math.max(precioVenta - precioCompra, 0);
+  const plusvaliaMunicipal = plusvalia * (gastos.plusvaliaMunicipal / 100);
+
+  function calcIRPF(gain) {
+    let restante = gain;
+    let impuesto = 0;
+    const tramos = [
+      { limite: 6000, tipo: 0.19 },
+      { limite: 44000, tipo: 0.21 },
+      { limite: Infinity, tipo: 0.23 },
+    ];
+    for (const tramo of tramos) {
+      const importe = Math.min(restante, tramo.limite);
+      impuesto += importe * tramo.tipo;
+      restante -= importe;
+      if (restante <= 0) break;
+    }
+    return impuesto;
+  }
+
+  const impuestoRenta = calcIRPF(plusvalia);
+  const comision = precioVenta * (gastos.comisionAgencia / 100);
+  const notaria = precioVenta * (gastos.notaria / 100);
+  const registro = precioVenta * (gastos.registro / 100);
+  const gestoria = precioVenta * (gastos.gestoria / 100);
+  const otros = precioVenta * (gastos.otros / 100);
+
+  const totalGastos = plusvaliaMunicipal + impuestoRenta + comision + notaria + registro + gestoria + otros + hipotecaPendiente;
+  const neto = precioVenta - totalGastos;
+
+  React.useEffect(() => {
+    onNeto(neto);
+  }, [neto]);
+
+  const handleGastoChange = (campo, valor) => {
+    setGastos(prev => ({ ...prev, [campo]: parseFloat(valor) }));
+  };
+
+  return (
+    <div className="bg-white p-4 rounded shadow">
+      <h2 className="text-xl font-bold mb-4">Módulo 1: Venta de Vivienda</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block">Precio Venta (€)</label>
+          <input type="number" className="border p-2 w-full" value={precioVenta} onChange={e=>setPrecioVenta(parseFloat(e.target.value)||0)} />
+        </div>
+        <div>
+          <label className="block">Precio Compra (€)</label>
+          <input type="number" className="border p-2 w-full" value={precioCompra} onChange={e=>setPrecioCompra(parseFloat(e.target.value)||0)} />
+        </div>
+        <div>
+          <label className="block">Años Propiedad</label>
+          <input type="number" className="border p-2 w-full" value={añosPropiedad} onChange={e=>setAñosPropiedad(parseInt(e.target.value)||0)} />
+        </div>
+        <div>
+          <label className="block">Hipoteca Pendiente (€)</label>
+          <input type="number" className="border p-2 w-full" value={hipotecaPendiente} onChange={e=>setHipotecaPendiente(parseFloat(e.target.value)||0)} />
+        </div>
+      </div>
+
+      <h3 className="text-lg font-semibold mt-4 mb-2">Gastos (%)</h3>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Object.keys(gastos).map(key => (
+          <div key={key}>
+            <label className="block capitalize">{key}</label>
+            <input type="number" className="border p-2 w-full" value={gastos[key]} onChange={e=>handleGastoChange(key,e.target.value)} />
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4">
+        <p>Plusvalía bruta: {plusvalia.toFixed(2)} €</p>
+        <p>Impuesto Plusvalía Municipal: {plusvaliaMunicipal.toFixed(2)} €</p>
+        <p>IRPF Ganancia Patrimonial: {impuestoRenta.toFixed(2)} €</p>
+        <p>Comisión Agencia: {comision.toFixed(2)} €</p>
+        <p>Notaría: {notaria.toFixed(2)} €</p>
+        <p>Registro: {registro.toFixed(2)} €</p>
+        <p>Gestoría: {gestoria.toFixed(2)} €</p>
+        <p>Otros: {otros.toFixed(2)} €</p>
+        <p>Hipoteca Pendiente: {hipotecaPendiente.toFixed(2)} €</p>
+        <p className="font-bold text-xl mt-2">DINERO NETO FINAL: <span className={neto>=0?"text-green-600":"text-red-600"}>{neto.toFixed(2)} €</span></p>
+      </div>
+    </div>
+  );
+}
+
+function InversionSimulator({ capitalDisponible, setCapitalDisponible }) {
+  const [propiedades, setPropiedades] = useState([]);
+
+  const addPropiedad = () => {
+    setPropiedades(prev => [...prev, {
+      id: Date.now(),
+      precioCompra: 150000,
+      entradaPorcentaje: 20,
+      plazoHipoteca: 25,
+      tipoInteres: 3.5,
+      gastosCompra: 12,
+      gastosReforma: 0,
+      habitaciones: 3,
+      alquilerPorHabitacion: 400,
+      gastosMensuales: 150,
+      vacacionalPorcentaje: 8,
+    }]);
+  };
+
+  const removePropiedad = (id) => {
+    setPropiedades(prev => prev.filter(p=>p.id!==id));
+  };
+
+  const handleChange = (id, campo, valor) => {
+    setPropiedades(prev => prev.map(p => p.id===id?{...p,[campo]:parseFloat(valor)||0}:p));
+  };
+
+  const calcular = (p) => {
+    const entrada = p.precioCompra * (p.entradaPorcentaje/100);
+    const hipoteca = p.precioCompra - entrada;
+    const tasaMensual = (p.tipoInteres/100)/12;
+    const n = p.plazoHipoteca*12;
+    const cuota = tasaMensual===0?hipoteca/n:(hipoteca*tasaMensual)/(1-Math.pow(1+tasaMensual,-n));
+    const ingresoBruto = p.habitaciones * p.alquilerPorHabitacion;
+    const ingresoNeto = ingresoBruto * (1 - p.vacacionalPorcentaje/100) - p.gastosMensuales;
+    const cashflow = ingresoNeto - cuota;
+    const inversionInicial = entrada + (p.precioCompra * (p.gastosCompra/100)) + p.gastosReforma;
+    const roi = inversionInicial>0? (cashflow*12)/inversionInicial : 0;
+    const rentabilidad = (ingresoNeto*12)/p.precioCompra;
+    return { entrada, hipoteca, cuota, ingresoBruto, ingresoNeto, cashflow, roi, rentabilidad };
+  };
+
+  const resumen = propiedades.reduce((acc,p)=>{
+    const r = calcular(p);
+    acc.capitalUsado += r.entrada + (p.precioCompra*(p.gastosCompra/100)) + p.gastosReforma;
+    acc.cashflowTotal += r.cashflow;
+    acc.roiTotal += r.roi;
+    acc.rentabilidadTotal += r.rentabilidad;
+    return acc;
+  }, {capitalUsado:0,cashflowTotal:0,roiTotal:0,rentabilidadTotal:0});
+
+  return (
+    <div className="bg-white p-4 rounded shadow">
+      <h2 className="text-xl font-bold mb-4">Módulo 2: Simulador de Inversión</h2>
+      <div className="mb-4">
+        <label className="block">Capital Disponible (€)</label>
+        <input type="number" className="border p-2 w-full" value={capitalDisponible} onChange={e=>setCapitalDisponible(parseFloat(e.target.value)||0)} />
+      </div>
+      <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={addPropiedad}>Añadir Propiedad</button>
+
+      {propiedades.map(p => {
+        const r = calcular(p);
+        return (
+          <div key={p.id} className="mt-4 border p-4 rounded">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="font-semibold">Propiedad #{p.id}</h3>
+              <button className="text-red-600" onClick={()=>removePropiedad(p.id)}>Eliminar</button>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <label className="block">Precio Compra (€)</label>
+                <input type="number" className="border p-2 w-full" value={p.precioCompra} onChange={e=>handleChange(p.id,'precioCompra',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Entrada (%)</label>
+                <input type="number" className="border p-2 w-full" value={p.entradaPorcentaje} onChange={e=>handleChange(p.id,'entradaPorcentaje',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Plazo Hipoteca (años)</label>
+                <input type="number" className="border p-2 w-full" value={p.plazoHipoteca} onChange={e=>handleChange(p.id,'plazoHipoteca',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Interés (%)</label>
+                <input type="number" className="border p-2 w-full" value={p.tipoInteres} onChange={e=>handleChange(p.id,'tipoInteres',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Gastos Compra (%)</label>
+                <input type="number" className="border p-2 w-full" value={p.gastosCompra} onChange={e=>handleChange(p.id,'gastosCompra',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Gastos Reforma (€)</label>
+                <input type="number" className="border p-2 w-full" value={p.gastosReforma} onChange={e=>handleChange(p.id,'gastosReforma',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Habitaciones</label>
+                <input type="number" className="border p-2 w-full" value={p.habitaciones} onChange={e=>handleChange(p.id,'habitaciones',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Alquiler por Habitación (€)</label>
+                <input type="number" className="border p-2 w-full" value={p.alquilerPorHabitacion} onChange={e=>handleChange(p.id,'alquilerPorHabitacion',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Gastos Mensuales (€)</label>
+                <input type="number" className="border p-2 w-full" value={p.gastosMensuales} onChange={e=>handleChange(p.id,'gastosMensuales',e.target.value)} />
+              </div>
+              <div>
+                <label className="block">Vacacional (%)</label>
+                <input type="number" className="border p-2 w-full" value={p.vacacionalPorcentaje} onChange={e=>handleChange(p.id,'vacacionalPorcentaje',e.target.value)} />
+              </div>
+            </div>
+            <div className="mt-2">
+              <p>Cuota Hipoteca: {r.cuota.toFixed(2)} €/mes</p>
+              <p>Ingresos Brutos: {r.ingresoBruto.toFixed(2)} €/mes</p>
+              <p>Ingresos Netos: {r.ingresoNeto.toFixed(2)} €/mes</p>
+              <p>Cash Flow: <span className={r.cashflow>=0?"text-green-600":"text-red-600"}>{r.cashflow.toFixed(2)} €/mes</span></p>
+              <p>ROI anual: {(r.roi*100).toFixed(2)}%</p>
+              <p>Rentabilidad neta anual: {(r.rentabilidad*100).toFixed(2)}%</p>
+            </div>
+          </div>
+        );
+      })}
+
+      {propiedades.length>0 && (
+        <div className="mt-4 p-4 bg-gray-50 rounded">
+          <p>Capital utilizado: {resumen.capitalUsado.toFixed(2)} € / Disponible: {capitalDisponible.toFixed(2)} €</p>
+          <p>Cash Flow mensual total: {resumen.cashflowTotal.toFixed(2)} €</p>
+          <p>ROI promedio: {(propiedades.length ? (resumen.roiTotal/propiedades.length)*100 : 0).toFixed(2)}%</p>
+          <p>Rentabilidad anual total: {(propiedades.length ? (resumen.rentabilidadTotal/propiedades.length)*100 : 0).toFixed(2)}%</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary
- scaffold simple React+Tailwind web app via CDN
- implement housing sale calculator with configurable expenses
- add multi-property investment simulator with ROI and cash flow metrics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689772c62d64832896acb8d3324ab43d